### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/samples/w3cptf-multiattr-tests.html
+++ b/samples/w3cptf-multiattr-tests.html
@@ -22,7 +22,7 @@ should be filed as issues in the <a href="https://github.com/w3c/pronunciation">
     increased to 25209 from 24976 over the past 10 years.</p>
 <p>Case 1: Audio rendering <audio  controls src="audio\case-say-as.mp3" />
 <h2>Case 2: Phoneme</h2>
-<p>Once upon a midnight <span data-ssml-alphabet="ipa" data-ssml-phoneme-ph="ˈdrɪəri">dreary</span></p>
+<p>Once upon a midnight <span data-ssml-phoneme-alphabet="ipa" data-ssml-phoneme-ph="ˈdrɪəri">dreary</span></p>
 <p>Case 2: Audio rendering <audio  controls src="audio\case-phoneme.mp3" />
 <h2>Case 3: sub</h2>
 <p><span data-ssml-sub-alias="Sodium Chloride">NaCL</span></p>

--- a/technical-approach/index.html
+++ b/technical-approach/index.html
@@ -359,7 +359,7 @@ increased to 25209 from 24976 over the past 10 years.
 							EXAMPLE 3
 							<pre>
 
-Once upon a midnight &lt;span data-ssml-alphabet="ipa" data-ssml-phoneme-ph="ˈdrɪəri"&gt;dreary&lt;/span&gt;
+Once upon a midnight &lt;span data-ssml-phoneme-alphabet="ipa" data-ssml-phoneme-ph="ˈdrɪəri"&gt;dreary&lt;/span&gt;
 						</pre>
 						</div>
 					</section>


### PR DESCRIPTION
I noticed that there are two cases of a mistyped attribute in the documents:
Expected: `data-ssml-phoneme-alphabet`
Actual: `data-ssml-alphabet`

My changes fix these two instances and I don't think they count as "substantive contributions to specifications", so hopefully this fix can be merged